### PR TITLE
chore: deprecating qb callback handling in favor of ox_lib callbacks

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -169,6 +169,7 @@ end)
 -- Callback Events --
 
 -- Client Callback
+---@deprecated call a function instead
 RegisterNetEvent('QBCore:Client:TriggerClientCallback', function(name, ...)
     QBCore.Functions.TriggerClientCallback(name, function(...)
         TriggerServerEvent('QBCore:Server:TriggerClientCallback', name, ...)
@@ -176,6 +177,7 @@ RegisterNetEvent('QBCore:Client:TriggerClientCallback', function(name, ...)
 end)
 
 -- Server Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 RegisterNetEvent('QBCore:Client:TriggerCallback', function(name, ...)
     if QBCore.ServerCallbacks[name] then
         QBCore.ServerCallbacks[name](...)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -138,16 +138,19 @@ end
 -- Callback Functions --
 
 -- Client Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 function QBCore.Functions.CreateClientCallback(name, cb)
     QBCore.ClientCallbacks[name] = cb
 end
 
+---@deprecated call a function instead
 function QBCore.Functions.TriggerClientCallback(name, cb, ...)
     if not QBCore.ClientCallbacks[name] then return end
     QBCore.ClientCallbacks[name](cb, ...)
 end
 
 -- Server Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 function QBCore.Functions.TriggerCallback(name, cb, ...)
     QBCore.ServerCallbacks[name] = cb
     TriggerServerEvent('QBCore:Server:TriggerCallback', name, ...)

--- a/client/main.lua
+++ b/client/main.lua
@@ -2,8 +2,13 @@ QBCore = {}
 QBCore.PlayerData = {}
 QBCore.Config = QBConfig
 QBCore.Shared = QBShared
+
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 QBCore.ClientCallbacks = {}
+
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 QBCore.ServerCallbacks = {}
+
 IsLoggedIn = false
 
 exports('GetCoreObject', function()

--- a/server/events.lua
+++ b/server/events.lua
@@ -158,6 +158,7 @@ end)
 -- Callback Events --
 
 -- Client Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 RegisterNetEvent('QBCore:Server:TriggerClientCallback', function(name, ...)
     if QBCore.ClientCallbacks[name] then
         QBCore.ClientCallbacks[name](...)
@@ -166,6 +167,7 @@ RegisterNetEvent('QBCore:Server:TriggerClientCallback', function(name, ...)
 end)
 
 -- Server Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 RegisterNetEvent('QBCore:Server:TriggerCallback', function(name, ...)
     local src = source
     QBCore.Functions.TriggerCallback(name, src, function(...)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -207,16 +207,19 @@ end
 -- Callback Functions --
 
 -- Client Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 function QBCore.Functions.TriggerClientCallback(name, source, cb, ...)
     QBCore.ClientCallbacks[name] = cb
     TriggerClientEvent('QBCore:Client:TriggerClientCallback', source, name, ...)
 end
 
 -- Server Callback
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 function QBCore.Functions.CreateCallback(name, cb)
     QBCore.ServerCallbacks[name] = cb
 end
 
+---@deprecated call a function instead
 function QBCore.Functions.TriggerCallback(name, source, cb, ...)
     if not QBCore.ServerCallbacks[name] then return end
     QBCore.ServerCallbacks[name](source, cb, ...)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,7 +1,11 @@
 QBCore = {}
 QBCore.Config = QBConfig
 QBCore.Shared = QBShared
+
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 QBCore.ClientCallbacks = {}
+
+---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 QBCore.ServerCallbacks = {}
 
 exports('GetCoreObject', function()


### PR DESCRIPTION
## Description

ox_lib callbacks are easier to work with, and more readable.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
