### PR TITLE
feat(server)!: Vehicle Spawning Overhaul

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -1,3 +1,5 @@
+local utils = require 'client.utils'
+
 -- Player load and unload handling
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     ShutdownLoadingScreenNui()
@@ -129,22 +131,22 @@ end)
 
 -- Vehicle Commands
 
----internal event to core. Do not invoke.
----@param vehicle number
-RegisterNetEvent('QBCore:Command:SpawnVehicle', function(netId)
+utils.entityStateHandler('initVehicle', function(entity, _, value)
+    if not value or NetworkGetEntityOwner(entity) ~= cache.playerId then return end
     if cache.vehicle then
         DeleteVehicle(cache.vehicle)
     end
 
-    local vehicle
-    repeat
-        vehicle = NetToVeh(netId)
-        Wait(0)
-    until DoesEntityExist(vehicle)
+    local veh = entity
 
-    SetVehicleFuelLevel(vehicle, 100.0)
-    SetVehicleDirtLevel(vehicle, 0.0)
-    TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(vehicle))
+    SetVehicleHasBeenOwnedByPlayer(veh, true)
+    SetNetworkIdCanMigrate(netId, true)
+    SetVehicleNeedsToBeHotwired(veh, false)
+    SetVehRadioStation(veh, 'OFF')
+    SetVehicleFuelLevel(veh, 100.0)
+    SetVehicleDirtLevel(veh, 0.0)
+    TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
+    Entity(entity).state:set('initVehicle', nil, true)
 end)
 
 RegisterNetEvent('QBCore:Command:DeleteVehicle', function()

--- a/client/events.lua
+++ b/client/events.lua
@@ -129,25 +129,21 @@ end)
 
 -- Vehicle Commands
 
----@param vehName string
-RegisterNetEvent('QBCore:Command:SpawnVehicle', function(vehName)
-    local hash = joaat(vehName)
-    if not IsModelInCdimage(hash) then return end
-    RequestModel(hash)
-    while not HasModelLoaded(hash) do
-        Wait(0)
-    end
-
+---internal event to core. Do not invoke.
+---@param vehicle number
+RegisterNetEvent('QBCore:Command:SpawnVehicle', function(netId)
     if cache.vehicle then
         DeleteVehicle(cache.vehicle)
     end
 
-    local coords = GetEntityCoords(cache.ped)
-    local vehicle = CreateVehicle(hash, coords.x, coords.y, coords.z, GetEntityHeading(cache.ped), true, false)
-    TaskWarpPedIntoVehicle(cache.ped, vehicle, -1)
+    local vehicle
+    repeat
+        vehicle = NetToVeh(netId)
+        Wait(0)
+    until DoesEntityExist(vehicle)
+
     SetVehicleFuelLevel(vehicle, 100.0)
     SetVehicleDirtLevel(vehicle, 0.0)
-    SetModelAsNoLongerNeeded(hash)
     TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(vehicle))
 end)
 

--- a/client/events.lua
+++ b/client/events.lua
@@ -132,7 +132,17 @@ end)
 -- Vehicle Commands
 
 utils.entityStateHandler('initVehicle', function(entity, _, value)
-    if not value or NetworkGetEntityOwner(entity) ~= cache.playerId then return end
+    if not value then return end
+    
+    for i = -1, 0 do
+        local ped = GetPedInVehicleSeat(entity, i)
+
+        if ped ~= cache.ped and ped > 0 and NetworkGetEntityOwner(ped) == cache.playerId then
+            DeleteEntity(ped)
+        end
+    end
+    
+    if NetworkGetEntityOwner(entity) ~= cache.playerId then return end
     if cache.vehicle then
         DeleteVehicle(cache.vehicle)
     end

--- a/client/events.lua
+++ b/client/events.lua
@@ -147,15 +147,11 @@ utils.entityStateHandler('initVehicle', function(entity, _, value)
         DeleteVehicle(cache.vehicle)
     end
 
-    local veh = entity
-
-    SetVehicleHasBeenOwnedByPlayer(veh, true)
-    SetNetworkIdCanMigrate(netId, true)
-    SetVehicleNeedsToBeHotwired(veh, false)
-    SetVehRadioStation(veh, 'OFF')
-    SetVehicleFuelLevel(veh, 100.0)
-    SetVehicleDirtLevel(veh, 0.0)
-    TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
+    SetVehicleNeedsToBeHotwired(entity, false)
+    SetVehRadioStation(entity, 'OFF')
+    SetVehicleFuelLevel(entity, 100.0)
+    SetVehicleDirtLevel(entity, 0.0)
+    TriggerEvent('vehiclekeys:client:SetOwner', QBCore.Functions.GetPlate(veh))
     Entity(entity).state:set('initVehicle', nil, true)
 end)
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -409,24 +409,20 @@ end
 ---@param model string|number
 ---@param cb? fun(vehicle: number)
 ---@param coords? vector3 player position if not specified
----@param isnetworked? boolean defaults to true
----@param teleportInto boolean teleport player to driver seat if true
-function QBCore.Functions.SpawnVehicle(model, cb, coords, isnetworked, teleportInto)
-    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
-    model = type(model) == 'string' and joaat(model) or model
-    if not IsModelInCdimage(model) then return end
+---@param teleportInto? boolean teleport player to driver seat if true
+function QBCore.Functions.SpawnVehicle(model, cb, coords, _, teleportInto)
+    local netId = lib.callback.await('qbx-core:server:createVehicle', false, model, coords, teleportInto)
+    local veh
+    repeat
+        veh = NetToVeh(netId)
+        Wait(0)
+    until DoesEntityExist(veh)
 
-    isnetworked = isnetworked == nil or isnetworked
-    QBCore.Functions.LoadModel(model)
-    local veh = CreateVehicle(model, coords.x, coords.y, coords.z, coords.w, isnetworked, false)
-    local netid = NetworkGetNetworkIdFromEntity(veh)
     SetVehicleHasBeenOwnedByPlayer(veh, true)
     SetNetworkIdCanMigrate(netid, true)
     SetVehicleNeedsToBeHotwired(veh, false)
     SetVehRadioStation(veh, 'OFF')
     SetVehicleFuelLevel(veh, 100.0)
-    SetModelAsNoLongerNeeded(model)
-    if teleportInto then TaskWarpPedIntoVehicle(cache.ped, veh, -1) end
     if cb then cb(veh) end
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -406,23 +406,29 @@ end
 
 -- Vehicle
 
+---@deprecated call server function QBCore.Functions.CreateVehicle instead.
 ---@param model string|number
 ---@param cb? fun(vehicle: number)
 ---@param coords? vector3 player position if not specified
----@param teleportInto? boolean teleport player to driver seat if true
-function QBCore.Functions.SpawnVehicle(model, cb, coords, _, teleportInto)
-    local netId = lib.callback.await('qbx-core:server:createVehicle', false, model, coords, teleportInto)
-    local veh
-    repeat
-        veh = NetToVeh(netId)
-        Wait(0)
-    until DoesEntityExist(veh)
+---@param isnetworked? boolean defaults to true
+---@param teleportInto boolean teleport player to driver seat if true
+function QBCore.Functions.SpawnVehicle(model, cb, coords, isnetworked, teleportInto)
+    print(string.format("%s invoked deprecated client function QBCore.Functions.SpawnVehicle. call server function QBCore.Functions.CreateVehicle instead.", GetInvokingResource()))
+    coords = type(coords) == 'table' and vec3(coords.x, coords.y, coords.z) or coords or GetEntityCoords(cache.ped)
+    model = type(model) == 'string' and joaat(model) or model
+    if not IsModelInCdimage(model) then return end
 
+    isnetworked = isnetworked == nil or isnetworked
+    QBCore.Functions.LoadModel(model)
+    local veh = CreateVehicle(model, coords.x, coords.y, coords.z, coords.w, isnetworked, false)
+    local netid = NetworkGetNetworkIdFromEntity(veh)
     SetVehicleHasBeenOwnedByPlayer(veh, true)
     SetNetworkIdCanMigrate(netid, true)
     SetVehicleNeedsToBeHotwired(veh, false)
     SetVehRadioStation(veh, 'OFF')
     SetVehicleFuelLevel(veh, 100.0)
+    SetModelAsNoLongerNeeded(model)
+    if teleportInto then TaskWarpPedIntoVehicle(cache.ped, veh, -1) end
     if cb then cb(veh) end
 end
 

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -20,6 +20,8 @@
 -- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 -- SOFTWARE.
 
+local utils = {}
+
 ---@async
 function utils.waitFor(cb, timeout)
     local hasValue = cb()

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -1,0 +1,76 @@
+-- MIT License
+
+-- Copyright (c) 2022 Overextended
+
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+---@async
+function utils.waitFor(cb, timeout)
+    local hasValue = cb()
+    local i = 0
+
+    while not hasValue do
+        if timeout then
+            i += 1
+
+            if i > timeout then return end
+        end
+
+        Wait(0)
+        hasValue = cb()
+    end
+
+    return hasValue
+end
+
+---@async
+---@param bagName string
+---@return integer?, integer
+function utils.getEntityAndNetIdFromBagName(bagName)
+    local netId = tonumber(bagName:gsub('entity:', ''), 10)
+
+    if not utils.waitFor(function()
+        return NetworkDoesEntityExistWithNetworkId(netId)
+    end, 10000) then
+        return print(('statebag timed out while awaiting entity creation! (%s)'):format(bagName)), 0
+    end
+
+    local entity = NetworkGetEntityFromNetworkId(netId)
+
+    if entity == 0 then
+        return print(('statebag received invalid entity! (%s)'):format(bagName)), 0
+    end
+
+    return entity, netId
+end
+
+---@param keyFilter string
+---@param cb fun(entity: number, netId: number, value: any, bagName: string)
+---@return number
+function utils.entityStateHandler(keyFilter, cb)
+    return AddStateBagChangeHandler(keyFilter, '', function(bagName, key, value, reserved, replicated)
+        local entity, netId = utils.getEntityAndNetIdFromBagName(bagName)
+
+        if entity then
+            cb(entity, netId, value, bagName)
+        end
+    end)
+end
+
+return utils

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -33,7 +33,7 @@ server_scripts {
     'server/storage.lua',
 }
 
-files = {
+files {
     'client/utils.lua',
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -33,6 +33,10 @@ server_scripts {
     'server/storage.lua',
 }
 
+files = {
+    'client/utils.lua',
+}
+
 dependency 'oxmysql'
 provide 'qb-core'
 lua54 'yes'

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -184,7 +184,8 @@ end, 'admin')
 -- Vehicle
 
 QBCore.Commands.Add('car', Lang:t("command.car.help"), {{ name = Lang:t("command.car.params.model.name"), help = Lang:t("command.car.params.model.help") }}, true, function(source, args)
-    TriggerClientEvent('QBCore:Command:SpawnVehicle', source, args[1])
+    local veh = QBCore.Functions.CreateVehicle(source, args[1], nil, true)
+    TriggerClientEvent('QBCore:Command:SpawnVehicle', source, veh)
 end, 'admin')
 
 QBCore.Commands.Add('dv', Lang:t("command.dv.help"), {}, false, function(source)

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -184,8 +184,7 @@ end, 'admin')
 -- Vehicle
 
 QBCore.Commands.Add('car', Lang:t("command.car.help"), {{ name = Lang:t("command.car.params.model.name"), help = Lang:t("command.car.params.model.help") }}, true, function(source, args)
-    local veh = QBCore.Functions.CreateVehicle(source, args[1], nil, true)
-    TriggerClientEvent('QBCore:Command:SpawnVehicle', source, veh)
+    QBCore.Functions.CreateVehicle(source, args[1], nil, true)
 end, 'admin')
 
 QBCore.Commands.Add('dv', Lang:t("command.dv.help"), {}, false, function(source)

--- a/server/events.lua
+++ b/server/events.lua
@@ -224,52 +224,18 @@ RegisterNetEvent('QBCore:CallCommand', function(command, args)
     end
 end)
 
--- vehicle server-side spawning callback (netId)
--- use the netid on the client with the NetworkGetEntityFromNetworkId native
--- convert it to a vehicle via the NetToVeh native but use a while loop before that to check if the vehicle exists first like this
---[[
-    ```lua
-        while not DoesEntityExist(NetToVeh(veh)) do
-            Wait(0)
-        end
-    ```
-]]
--- If you don't use the above on the client, it will return 0 as the vehicle from the netid and 0 means no vehicle found because it doesn't exist so fast on the client
----@param source number
----@param model string|number
----@param coords vector4
----@param warp boolean
----@return number? vehNetId
-local function createVehicle(source, model, coords, warp)
-    local ped = GetPlayerPed(source)
-    model = type(model) == 'string' and joaat(model) or model
-    if not coords then coords = GetEntityCoords(ped) end
-    if not CreateVehicleServerSetter then
-        error('^1CreateVehicleServerSetter is not available on your artifact, please use artifact 5904 or above to be able to use this^0')
-        return
-    end
-    local tempVehicle = CreateVehicle(model, 0, 0, 0, 0, true, true)
-    while not DoesEntityExist(tempVehicle) do Wait(0) end
-    local vehicleType = GetVehicleType(tempVehicle)
-    DeleteEntity(tempVehicle)
-    local veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
-    while not DoesEntityExist(veh) do Wait(0) end
-    if warp then TaskWarpPedIntoVehicle(ped, veh, -1) end
-    return NetworkGetNetworkIdFromEntity(veh)
-end
-
-lib.callback.register('qbx-core:server:createVehicle', createVehicle)
+lib.callback.register('qbx-core:server:createVehicle', QBCore.Functions.CreateVehicle)
 
 ---@deprecated use 'qbx-core:server:createVehicle' via ox_lib callback instead.
 QBCore.Functions.CreateCallback('QBCore:Server:SpawnVehicle', function(source, cb, model, coords, warp)
     print(string.format("%s invoked deprecated callback QBCore:Server:SpawnVehicle. Use qbx-core:server:createVehicle via ox_lib callback instead.", GetInvokingResource()))
-    local netId = createVehicle(source, model, coords, warp)
+    local netId = QBCore.Functions.CreateVehicle(source, model, coords, warp)
     if netId then cb(netId) end
 end)
 
 ---@deprecated use 'qbx-core:server:createVehicle' via ox_lib callback instead.
 QBCore.Functions.CreateCallback('QBCore:Server:CreateVehicle', function(source, cb, model, coords, warp)
     print(string.format("%s invoked deprecated callback QBCore:Server:CreateVehicle. Use qbx-core:server:createVehicle via ox_lib callback instead.", GetInvokingResource()))
-    local netId = createVehicle(source, model, coords, warp)
+    local netId = QBCore.Functions.CreateVehicle(source, model, coords, warp)
     if netId then cb(netId) end
 end)

--- a/server/events.lua
+++ b/server/events.lua
@@ -224,18 +224,16 @@ RegisterNetEvent('QBCore:CallCommand', function(command, args)
     end
 end)
 
-lib.callback.register('qbx-core:server:createVehicle', QBCore.Functions.CreateVehicle)
-
----@deprecated use 'qbx-core:server:createVehicle' via ox_lib callback instead.
+---@deprecated call server function QBCore.Functions.CreateVehicle instead.
 QBCore.Functions.CreateCallback('QBCore:Server:SpawnVehicle', function(source, cb, model, coords, warp)
-    print(string.format("%s invoked deprecated callback QBCore:Server:SpawnVehicle. Use qbx-core:server:createVehicle via ox_lib callback instead.", GetInvokingResource()))
+    print(string.format("%s invoked deprecated callback QBCore:Server:SpawnVehicle. Call server function QBCore.Functions.CreateVehicle instead.", GetInvokingResource()))
     local netId = QBCore.Functions.CreateVehicle(source, model, coords, warp)
     if netId then cb(netId) end
 end)
 
----@deprecated use 'qbx-core:server:createVehicle' via ox_lib callback instead.
+---@deprecated call server function QBCore.Functions.CreateVehicle instead.
 QBCore.Functions.CreateCallback('QBCore:Server:CreateVehicle', function(source, cb, model, coords, warp)
-    print(string.format("%s invoked deprecated callback QBCore:Server:CreateVehicle. Use qbx-core:server:createVehicle via ox_lib callback instead.", GetInvokingResource()))
+    print(string.format("%s invoked deprecated callback QBCore:Server:CreateVehicle. call server function QBCore.Functions.CreateVehicle instead.", GetInvokingResource()))
     local netId = QBCore.Functions.CreateVehicle(source, model, coords, warp)
     if netId then cb(netId) end
 end)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -238,8 +238,7 @@ function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     local veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
     while not DoesEntityExist(veh) do Wait(0) end
     if warp then TaskWarpPedIntoVehicle(GetPlayerPed(source), veh, -1) end
-    local state = Entity(veh).state
-    state:set('initVehicle', true, true)
+    Entity(veh).state:set('initVehicle', true, true)
     return NetworkGetNetworkIdFromEntity(veh)
 end
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -238,6 +238,8 @@ function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     local veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
     while not DoesEntityExist(veh) do Wait(0) end
     if warp then TaskWarpPedIntoVehicle(GetPlayerPed(source), veh, -1) end
+    local state = Entity(veh).state
+    state:set('initVehicle', true, true)
     return NetworkGetNetworkIdFromEntity(veh)
 end
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -211,8 +211,8 @@ end
 -- The CreateVehicleServerSetter native uses only the server to create a vehicle instead of using the client as well
 ---@param source Source
 ---@param model string|number
----@param coords vector4
----@param warp boolean
+---@param coords? vector4 default to player's position
+---@param warp? boolean
 ---@return number?
 function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     model = type(model) == 'string' and joaat(model) or model

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -201,27 +201,10 @@ function QBCore.Functions.GetEntitiesInBucket(bucket)
     return curr_bucket_pool
 end
 
--- Server side vehicle creation with optional callback
--- the CreateVehicle RPC still uses the client for creation so players must be near
----@param source Source
----@param model string|number
----@param coords vector4
----@param warp boolean
----@return number
+---@deprecated Use QBCore.Functions.CreateVehicle instead.
 function QBCore.Functions.SpawnVehicle(source, model, coords, warp)
-    local ped = GetPlayerPed(source)
-    model = type(model) == 'string' and joaat(model) or model
-    if not coords then coords = GetEntityCoords(ped) end
-    local veh = CreateVehicle(model, coords.x, coords.y, coords.z, coords.w, true, true)
-    while not DoesEntityExist(veh) do Wait(0) end
-    if warp then
-        while GetVehiclePedIsIn(ped, false) ~= veh do
-            Wait(0)
-            TaskWarpPedIntoVehicle(ped, veh, -1)
-        end
-    end
-    while NetworkGetEntityOwner(veh) ~= source do Wait(0) end
-    return veh
+    print(string.format("%s invoked deprecated server function QBCore.Functions.SpawnVehicle. Use QBCore.Functions.CreateVehicle instead.", GetInvokingResource()))
+    return QBCore.Functions.CreateVehicle(source, model, coords, warp)
 end
 
 -- Server side vehicle creation with optional callback
@@ -267,7 +250,7 @@ end
 
 ---@deprecated call a function instead
 function QBCore.Functions.TriggerCallback(name, source, cb, ...)
-    print(string.format("%s invoked deprecated function TriggerCallback. Use ox_lib callback functions instead.", GetInvokingResource()))
+    print(string.format("%s invoked deprecated function TriggerCallback. Call a function instead.", GetInvokingResource()))
     if not QBCore.ServerCallbacks[name] then return end
     QBCore.ServerCallbacks[name](source, cb, ...)
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -209,11 +209,21 @@ end
 
 -- Server side vehicle creation with optional callback
 -- The CreateVehicleServerSetter native uses only the server to create a vehicle instead of using the client as well
----@param source Source
+-- use the netid on the client with the NetworkGetEntityFromNetworkId native
+-- convert it to a vehicle via the NetToVeh native but use a while loop before that to check if the vehicle exists first like this
+--[[
+    ```lua
+        while not DoesEntityExist(NetToVeh(veh)) do
+            Wait(0)
+        end
+    ```
+]]
+-- If you don't use the above on the client, it will return 0 as the vehicle from the netid and 0 means no vehicle found because it doesn't exist so fast on the client
+---@param source number
 ---@param model string|number
 ---@param coords? vector4 default to player's position
 ---@param warp? boolean
----@return number?
+---@return number? netId
 function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     model = type(model) == 'string' and joaat(model) or model
     if not coords then coords = GetEntityCoords(GetPlayerPed(source)) end
@@ -228,7 +238,7 @@ function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     local veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
     while not DoesEntityExist(veh) do Wait(0) end
     if warp then TaskWarpPedIntoVehicle(GetPlayerPed(source), veh, -1) end
-    return veh
+    return NetworkGetNetworkIdFromEntity(veh)
 end
 
 -- Callback Functions --


### PR DESCRIPTION
## Description

- deprecating QB callbacks for creating/spawning vehicle in favor of new ox_lib callbacks
- deprecating vehicle creation functions/callbacks on the server which use CreateVehicle native rather than CreateVehicleServerSetter. Existing functions/callbacks are now wrappers.
- BREAKING CHANGE: 'QBCore:Server:CreateVehicle' server callback will now return nil rather than 0 if the server artifact is below 5904. This brings the behavior in-line with the function version.
- server events/functions which spawn vehicle refactored to call the server to spawn the vehicle
- BREAKING CHANGE: QBCore.Functions.CreateVehicle server function now returning the netId instead of the entityId. I'm too sure about whether this is a good change or not, but it seemed odd that the original callback returned the netId and the function returned the entityId, so I picked one and went with it.

Unrelated: I don't understand why the createVehicle function is spawning and deleting a temp vehicle.
Unrelated: Seems like the callback for spawning vehicles should live right next to the server function for spawning vehicles rather than have it in the 'events' file.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
