### PR TITLE
fix(server/functions): fix teleporting player into vehicle on spawn

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -236,8 +236,8 @@ function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     local vehicleType = GetVehicleType(tempVehicle)
     DeleteEntity(tempVehicle)
     local veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
-    while not DoesEntityExist(veh) do Wait(0) end
-    if warp then TaskWarpPedIntoVehicle(GetPlayerPed(source), veh, -1) end
+    Wait(0)
+    if warp then SetPedIntoVehicle(GetPlayerPed(source), veh, -1) end
     Entity(veh).state:set('initVehicle', true, true)
     return NetworkGetNetworkIdFromEntity(veh)
 end


### PR DESCRIPTION
## Description

- Did some testing with the native and found that the loop waiting for it to exist never runs any iterations and that a single frame wait is needed prior to teleporting player into vehicle.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
