### PR TITLE
fix: setting vehicle owner incorrectly on spawn

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -133,7 +133,7 @@ end)
 
 utils.entityStateHandler('initVehicle', function(entity, _, value)
     if not value then return end
-    
+
     for i = -1, 0 do
         local ped = GetPedInVehicleSeat(entity, i)
 
@@ -141,17 +141,12 @@ utils.entityStateHandler('initVehicle', function(entity, _, value)
             DeleteEntity(ped)
         end
     end
-    
-    if NetworkGetEntityOwner(entity) ~= cache.playerId then return end
-    if cache.vehicle then
-        DeleteVehicle(cache.vehicle)
-    end
 
+    if NetworkGetEntityOwner(entity) ~= cache.playerId then return end
     SetVehicleNeedsToBeHotwired(entity, false)
     SetVehRadioStation(entity, 'OFF')
     SetVehicleFuelLevel(entity, 100.0)
     SetVehicleDirtLevel(entity, 0.0)
-    TriggerEvent('vehiclekeys:client:SetOwner', QBCore.Functions.GetPlate(veh))
     Entity(entity).state:set('initVehicle', nil, true)
 end)
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -226,7 +226,6 @@ end
 ---@param warp? boolean
 ---@return number? netId
 function QBCore.Functions.CreateVehicle(source, model, coords, warp)
-
     model = type(model) == 'string' and joaat(model) or model
     if not coords then coords = GetEntityCoords(GetPlayerPed(source)) end
     if not CreateVehicleServerSetter then
@@ -235,8 +234,8 @@ function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     end
     local ped = GetPlayerPed(source)
     local currentVeh = GetVehiclePedIsIn(ped, false)
-    if currentVeh and currentVeh ~= 0 then DeleteEntity(currentVeh) end
-    
+    if currentVeh ~= 0 then DeleteEntity(currentVeh) end
+
     local tempVehicle = CreateVehicle(model, 0, 0, 0, 0, true, true)
     while not DoesEntityExist(tempVehicle) do Wait(0) end
     local vehicleType = GetVehicleType(tempVehicle)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -219,25 +219,33 @@ end
     ```
 ]]
 -- If you don't use the above on the client, it will return 0 as the vehicle from the netid and 0 means no vehicle found because it doesn't exist so fast on the client
+-- Deletes vehicle ped is in before spawning a new one.
 ---@param source number
 ---@param model string|number
 ---@param coords? vector4 default to player's position
 ---@param warp? boolean
 ---@return number? netId
 function QBCore.Functions.CreateVehicle(source, model, coords, warp)
+
     model = type(model) == 'string' and joaat(model) or model
     if not coords then coords = GetEntityCoords(GetPlayerPed(source)) end
     if not CreateVehicleServerSetter then
         error('^1CreateVehicleServerSetter is not available on your artifact, please use artifact 5904 or above to be able to use this^0')
         return
     end
+    local ped = GetPlayerPed(source)
+    local currentVeh = GetVehiclePedIsIn(ped, false)
+    if currentVeh and currentVeh ~= 0 then DeleteEntity(currentVeh) end
+    
     local tempVehicle = CreateVehicle(model, 0, 0, 0, 0, true, true)
     while not DoesEntityExist(tempVehicle) do Wait(0) end
     local vehicleType = GetVehicleType(tempVehicle)
     DeleteEntity(tempVehicle)
     local veh = CreateVehicleServerSetter(model, vehicleType, coords.x, coords.y, coords.z, coords.w)
     Wait(0)
-    if warp then SetPedIntoVehicle(GetPlayerPed(source), veh, -1) end
+
+    if warp then SetPedIntoVehicle(ped, veh, -1) end
+    TriggerClientEvent('vehiclekeys:client:SetOwner', source, QBCore.Functions.GetPlate(veh))
     Entity(veh).state:set('initVehicle', true, true)
     return NetworkGetNetworkIdFromEntity(veh)
 end


### PR DESCRIPTION
## Description

Giving keys and deleting current vehicle changed from client side state bag handler to now being done in the server side function to spawn vehicle. This fixes an issue where the network owner of the car was assumed to be the framework owner of the car; when in fact the two are completely different concepts.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
