### PR TITLE
fix: Player dont receive car keys on cars created server side

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -244,7 +244,7 @@ function QBCore.Functions.CreateVehicle(source, model, coords, warp)
     Wait(0)
 
     if warp then SetPedIntoVehicle(ped, veh, -1) end
-    TriggerClientEvent('vehiclekeys:client:SetOwner', source, QBCore.Functions.GetPlate(veh))
+    TriggerClientEvent('vehiclekeys:client:SetOwnerByNetworkId', source, NetworkGetNetworkIdFromEntity(veh))
     Entity(veh).state:set('initVehicle', true, true)
     return NetworkGetNetworkIdFromEntity(veh)
 end


### PR DESCRIPTION
## Description

Player are not receiving car keys on cars created on server-side, since the GetVehicleNumberPlateText is not working server side. Then i added an event on qbx-vehiclekeys i made a pr for it already, which receives the networkId of the car and converts it to entity to get the plate and give the keys.

Event:
RegisterNetEvent('vehiclekeys:client:SetOwnerByNetworkId', function(vehicleId)
    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', QBCore.Functions.GetPlate(NetworkGetEntityFromNetworkId(vehicleId)))
end)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
