### PR TITLE
staff permissions

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -32,6 +32,7 @@ server_scripts {
     'server/debug.lua',
     'server/loops.lua',
     'server/storage.lua',
+    'server/staff.lua'
 }
 
 modules {

--- a/server/staff.lua
+++ b/server/staff.lua
@@ -1,0 +1,49 @@
+--[[ 
+    example config:
+    for a god called BigDaddy with the fivem identifier "69420"
+    in server.cfg it would look like this:
+    add_principal identifier.fivem:69420 qbox.god
+
+    We'll use this:
+        ["BigDaddy"] = {
+            permission = "god",
+            identifiers = {
+                -- type = identifier
+                fivem = "69420",
+            }
+        } 
+
+    identifier types are:
+        license
+        license2
+        fivem
+        discord
+        steam
+    ]]
+local Staff = {
+    [""] = {
+        permission = "",
+        identifiers = {
+        }
+    }
+}
+
+AddEventHandler('playerJoining', function()
+    local identifiers = {}
+    for _, idtype in pairs({"license", "license2", "fivem", "discord", "steam"}) do
+        identifiers[idtype] = QBCore.Functions.GetIdentifier(source, idtype)
+    end
+    
+    local done = false
+    for _, member in pairs(Staff) do
+        for idtype, identifier in pairs(member.identifiers) do
+            if identifier and identifiers[idtype] == string.format("%s:%s", idtype, identifier) then
+                lib.addAce("player." .. source, string.format("group.%s", member.permission))
+                lib.addAce("player." .. source, string.format("qbox.%s", member.permission)) -- remove once we moved to group.permission
+                done = true
+                break
+            end
+        end
+        if done then break end
+    end
+end)


### PR DESCRIPTION
## Description

Adds permissions when player connects, fixes issue players seems to have currently where setting principals to identifiers doesn't work (but player.[source] works somehow)

+it better than adding lines in server.cfg (i guess?)

The Way i did it definitely isn't the best but it might be easier for config devs (i think)
If ya want i could just use only one identifier type and put the identifier as key, would remove loops.
Could also have a table for each identifier type i guess?
also might need to be addprincipals instead of ace? i don't really understand the whole principals/ace stuff (like i get aces but then what the hell are principals for?????)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
