### PR TITLE
Add Toggle Duty events when duty is changed.

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -296,6 +296,8 @@ function QBCore.Player.CreatePlayer(PlayerData, Offline)
     ---@param onDuty boolean
     function self.Functions.SetJobDuty(onDuty)
         self.PlayerData.job.onduty = not not onDuty -- Make sure the value is a boolean if nil is sent
+        TriggerEvent('QBCore:Server:SetDuty', self.PlayerData.source, self.PlayerData.job.onduty)
+        TriggerClientEvent('QBCore:Client:SetDuty', self.PlayerData.source, self.PlayerData.job.onduty)
         self.Functions.UpdatePlayerData()
     end
 


### PR DESCRIPTION
- A lot of other scripts listen to the toggle duty events instead of getting the whole playerdata object to get the latest duty status.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
