### PR TITLE
Prevent error when calling function

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -25,6 +25,11 @@ function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, perm
     end)
 end
 
+---@deprecated
+function QBCore.Commands.Refresh(source)
+    print(string.format("%s invoked deprecated function QBCore.Commands.Refresh. This is not being used anymore.", GetInvokingResource()))
+end
+
 -- Teleport
 
 lib.addCommand('tp', {

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -27,7 +27,7 @@ end
 
 ---@deprecated
 function QBCore.Commands.Refresh(source)
-    print(string.format("%s invoked deprecated function QBCore.Commands.Refresh. This is not being used anymore.", GetInvokingResource()))
+
 end
 
 -- Teleport


### PR DESCRIPTION
## Description

The following PR prevents an error when a resource calls QBCore.Commands.Refresh function since it doesn't exist in the core. This "fix" was suggested by Manason on Discord, I just took time to test it out and make sure it works.

I hope you guys are satisfied with the print :D 

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
