### PR TITLE
refactor(callback): change to ox_lib callbacks

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -173,25 +173,6 @@ RegisterNetEvent('QBCore:Notify', function(text, notifyType, duration, subTitle,
     QBCore.Functions.Notify(text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon, notifyIconColor)
 end)
 
--- Callback Events --
-
--- Client Callback
----@deprecated call a function instead
-RegisterNetEvent('QBCore:Client:TriggerClientCallback', function(name, ...)
-    QBCore.Functions.TriggerClientCallback(name, function(...)
-        TriggerServerEvent('QBCore:Server:TriggerClientCallback', name, ...)
-    end, ...)
-end)
-
--- Server Callback
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
-RegisterNetEvent('QBCore:Client:TriggerCallback', function(name, ...)
-    if QBCore.ServerCallbacks[name] then
-        QBCore.ServerCallbacks[name](...)
-        QBCore.ServerCallbacks[name] = nil
-    end
-end)
-
 -- Me command
 
 ---@param coords vector3

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -81,21 +81,14 @@ end
 
 -- Client Callback
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
-function QBCore.Functions.CreateClientCallback(name, cb)
-    QBCore.ClientCallbacks[name] = cb
-end
+QBCore.Functions.CreateClientCallback = lib.callback.register
 
 ---@deprecated call a function instead
-function QBCore.Functions.TriggerClientCallback(name, cb, ...)
-    if not QBCore.ClientCallbacks[name] then return end
-    QBCore.ClientCallbacks[name](cb, ...)
-end
+QBCore.Functions.TriggerClientCallback = noop
 
--- Server Callback
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 function QBCore.Functions.TriggerCallback(name, cb, ...)
-    QBCore.ServerCallbacks[name] = cb
-    TriggerServerEvent('QBCore:Server:TriggerCallback', name, ...)
+    lib.callback(name, false, cb, ...)
 end
 
 ---@deprecated use lib.progressBar from ox_lib

--- a/client/main.lua
+++ b/client/main.lua
@@ -3,12 +3,6 @@ QBCore.PlayerData = {}
 QBCore.Config = QBConfig
 QBCore.Shared = QBShared
 
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
-QBCore.ClientCallbacks = {}
-
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
-QBCore.ServerCallbacks = {}
-
 IsLoggedIn = false
 
 exports('GetCoreObject', function()

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -26,9 +26,7 @@ function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, perm
 end
 
 ---@deprecated
-function QBCore.Commands.Refresh(source)
-
-end
+QBCore.Commands.Refresh = noop
 
 -- Teleport
 

--- a/server/events.lua
+++ b/server/events.lua
@@ -167,26 +167,6 @@ RegisterNetEvent('QBCore:Server:OpenServer', function()
     end
 end)
 
--- Callback Events --
-
--- Client Callback
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
-RegisterNetEvent('QBCore:Server:TriggerClientCallback', function(name, ...)
-    if QBCore.ClientCallbacks[name] then
-        QBCore.ClientCallbacks[name](...)
-        QBCore.ClientCallbacks[name] = nil
-    end
-end)
-
--- Server Callback
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
-RegisterNetEvent('QBCore:Server:TriggerCallback', function(name, ...)
-    local src = source
-    QBCore.Functions.TriggerCallback(name, src, function(...)
-        TriggerClientEvent('QBCore:Client:TriggerCallback', src, name, ...)
-    end, ...)
-end)
-
 -- Player
 
 RegisterNetEvent('QBCore:ToggleDuty', function()

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -191,24 +191,15 @@ QBCore.Functions.CreateVehicle = SpawnVehicle
 
 -- Callback Functions --
 
--- Client Callback
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
-function QBCore.Functions.TriggerClientCallback(name, source, cb, ...)
-    QBCore.ClientCallbacks[name] = cb
-    TriggerClientEvent('QBCore:Client:TriggerClientCallback', source, name, ...)
-end
+QBCore.Functions.TriggerClientCallback = lib.callback
 
 -- Server Callback
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
-function QBCore.Functions.CreateCallback(name, cb)
-    QBCore.ServerCallbacks[name] = cb
-end
+QBCore.Functions.CreateCallback = lib.callback.register
 
 ---@deprecated call a function instead
-function QBCore.Functions.TriggerCallback(name, source, cb, ...)
-    if not QBCore.ServerCallbacks[name] then return end
-    QBCore.ServerCallbacks[name](source, cb, ...)
-end
+QBCore.Functions.TriggerCallback = noop
 
 -- Items
 ---@param item string name

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,12 +2,6 @@ QBCore = {}
 QBCore.Config = QBConfig
 QBCore.Shared = QBShared
 
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
-QBCore.ClientCallbacks = {}
-
----@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
-QBCore.ServerCallbacks = {}
-
 exports('GetCoreObject', function()
     return QBCore
 end)


### PR DESCRIPTION
## Description
changed the callbacks in the core to call the equivalent callbacks in ox_lib. as well as removing calling client callbacks and server callbacks from their own side (just weird and anyone using it isn't using code right).

changed the empty functions to use ox_lib/init.lua noop function to reduce memory usage slightly by not defining additional functions.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
