### PR TITLE
fix(server/events): `IsPlayerBanned` errors being ignored

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -88,7 +88,7 @@ local function onPlayerConnecting(name, _, deferrals)
             end
         end)
 
-        if QBCore.Config.Server.Whitelist then
+        if QBCore.Config.Server.Whitelist and databaseSuccess then
             deferrals.update(string.format(Lang:t('info.checking_whitelisted'), name))
             databaseSuccess, databaseError = pcall(function()
                 if not QBCore.Functions.IsWhitelisted(src --[[@as Source]]) then


### PR DESCRIPTION
## Description

If whitelist is enabled, the call to `IsWhitelisted` which follows `IsPlayerBanned` essentially overwrites the latter function's error, if one occurred.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
