### PR TITLE
refactor(server/events): use wording for a general error

### DIFF
--- a/locale/bg.lua
+++ b/locale/bg.lua
@@ -17,7 +17,6 @@ local Translations = {
         no_permission = 'Нямате разрешения за това ..',
         no_waypoint = 'Няма зададена точка.',
         tp_error = 'Грешка при телепортиране.',
-        connecting_database_error = 'Възникна грешка с базата данни при свързването към сървъра. (SQL сървърът работи ли?)',
         connecting_database_timeout = 'Свързването с базата данни изтече. (SQL сървърът работи ли?)',
     },
     success = {

--- a/locale/da.lua
+++ b/locale/da.lua
@@ -17,7 +17,6 @@ local Translations = {
         no_permission = 'Du har ikke adgang til at gøre dette',
         no_waypoint = 'Ingen waypoint sat.',
         tp_error = 'Fejl opstod mens du teleporterede.',
-        connecting_database_error = 'En database fejl opstod, mens du tilsluttede serveren. (Er SQL serveren tændt?)',
         connecting_database_timeout = 'Forbindelsen til databasen gik tabt. (Er SQL serveren tændt?)',
     },
     success = {

--- a/locale/en.lua
+++ b/locale/en.lua
@@ -17,8 +17,8 @@ local Translations = {
         no_permission = 'You don\'t have permissions for this..',
         no_waypoint = 'No Waypoint Set.',
         tp_error = 'Error While Teleporting.',
-        connecting_database_error = 'A database error occurred while connecting to the server. (Is the SQL server on?)',
         connecting_database_timeout = 'Connection to database timed out. (Is the SQL server on?)',
+        connecting_error = 'An error occurred while connecting to the server. (Check your server console)',
     },
     success = {
         server_opened = 'The server has been opened',

--- a/server/events.lua
+++ b/server/events.lua
@@ -81,7 +81,7 @@ local function onPlayerConnecting(name, _, deferrals)
     -- conduct database-dependant checks
     CreateThread(function()
         deferrals.update(string.format(Lang:t('info.checking_ban'), name))
-        local databaseSuccess, databaseError = pcall(function()
+        local success, err = pcall(function()
             local isBanned, Reason = QBCore.Functions.IsPlayerBanned(src --[[@as Source]])
             if isBanned then
                 deferrals.done(Reason)
@@ -90,15 +90,15 @@ local function onPlayerConnecting(name, _, deferrals)
 
         if QBCore.Config.Server.Whitelist then
             deferrals.update(string.format(Lang:t('info.checking_whitelisted'), name))
-            databaseSuccess, databaseError = pcall(function()
+            success, err = pcall(function()
                 if not QBCore.Functions.IsWhitelisted(src --[[@as Source]]) then
                     deferrals.done(Lang:t('error.not_whitelisted'))
                 end
             end)
         end
 
-        if not databaseSuccess then
-            databasePromise:reject(databaseError)
+        if not success then
+            databasePromise:reject(err)
         end
         databasePromise:resolve()
     end)
@@ -107,9 +107,9 @@ local function onPlayerConnecting(name, _, deferrals)
     databasePromise:next(function()
         deferrals.update(string.format(Lang:t('info.join_server'), name))
         deferrals.done()
-    end, function (databaseError)
-        deferrals.done(Lang:t('error.connecting_database_error'))
-        print('^1' .. databaseError)
+    end, function(err)
+        deferrals.done(Lang:t('error.connecting_error'))
+        print('^1' .. err)
     end)
 
     -- if conducting db checks for too long then raise error


### PR DESCRIPTION
## Description

Rephrases anything related to errors occurring when connecting to a server, since a general error can occur there rather than strictly a database-related one.

Replaces `connecting_database_error` with `connecting_error` completely since the former will lose meaning in all locales.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
