### PR TITLE
bugfix(qbx-core/sv): fix teleporting by id

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -41,22 +41,13 @@ lib.addCommand('tp', {
     },
     restricted = "group.admin"
 }, function(source, args)
-    if args[Lang:t("command.tp.params.x.name")] and not args[Lang:t("command.tp.params.y.name")] and not args[3] then
-        if tonumber(args[1]) then
-            local target = GetPlayerPed(tonumber(args[Lang:t("command.tp.params.x.name")]) --[[@as number]])
-            if target ~= 0 then
-                local coords = GetEntityCoords(target)
-                TriggerClientEvent('QBCore:Command:TeleportToPlayer', source, coords)
-            else
-                TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_online'), 'error')
-            end
+    if args[Lang:t("command.tp.params.x.name")] and not args[Lang:t("command.tp.params.y.name")] and not args[Lang:t("command.tp.params.z.name")] then
+        local target = GetPlayerPed(tonumber(args[Lang:t("command.tp.params.x.name")]) --[[@as number]])
+        if target ~= 0 then
+            local coords = GetEntityCoords(target)
+            TriggerClientEvent('QBCore:Command:TeleportToPlayer', source, coords)
         else
-            local location = QBShared.Locations[args[Lang:t("command.tp.params.x.name")]]
-            if location then
-                TriggerClientEvent('QBCore:Command:TeleportToCoords', source, location.x, location.y, location.z, location.w)
-            else
-                TriggerClientEvent('QBCore:Notify', source, Lang:t('error.location_not_exist'), 'error')
-            end
+            TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_online'), 'error')
         end
     else
         if args[Lang:t("command.tp.params.x.name")] and args[Lang:t("command.tp.params.y.name")] and args[Lang:t("command.tp.params.z.name")] then


### PR DESCRIPTION
## Description
Teleporting by id doesnt work.

do /tp 1 with someone else in the server and it will not permit user to get to them

Here is the bug report i got from my server community:
```we type /tp 3 while id 3 is online and it will say "Location Does Not Exist".```

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.