### PR TITLE
Chore/add bring command

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -65,6 +65,33 @@ lib.addCommand('tp', {
     end
 end)
 
+lib.addCommand('bring', {
+    help = 'bring player to you by id',
+    params = {
+        { name = 'id', help = 'id of player to bring', optional = false },
+    },
+    restricted = "group.admin"
+}, function(source, args)
+    if not args['id'] then
+        TriggerClientEvent('QBCore:Notify', source, 'We need an id to teleport to.', 'error')
+        return
+    end
+
+    local targetId = tonumber(args['id'])
+    local target = GetPlayerPed(targetId)
+    if source == targetId then
+        return TriggerClientEvent('QBCore:Notify', source, 'You cannot teleport to yourself.', 'error')
+    end
+
+    if target ~= 0 then
+        local playerPed = GetPlayerPed(source)
+        local coords = GetEntityCoords(playerPed)
+        TriggerClientEvent('QBCore:Command:TeleportToPlayer', targetId, coords)
+    else
+        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_online'), 'error')
+    end
+end)
+
 
 lib.addCommand('tpm', {
     help = Lang:t("command.tpm.help"),

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -66,31 +66,33 @@ lib.addCommand('tp', {
 end)
 
 lib.addCommand('bring', {
-    help = 'bring player to you by id',
+    help = 'bring player to you',
     params = {
-        { name = 'id', help = 'id of player to bring', optional = false },
+        { name = 'id', help = 'id to bring', optional = false },
     },
     restricted = "group.admin"
 }, function(source, args)
-    if not args['id'] then
-        TriggerClientEvent('QBCore:Notify', source, 'We need an id to teleport to.', 'error')
+    if not args['id'] or not tonumber(args['id']) then
+        TriggerClientEvent('QBCore:Notify', source, 'We need a valid numeric id to teleport to.', 'error')
         return
     end
 
     local targetId = tonumber(args['id'])
     local target = GetPlayerPed(targetId)
-    if source == targetId then
-        return TriggerClientEvent('QBCore:Notify', source, 'You cannot teleport to yourself.', 'error')
+
+    if target == 0 then
+        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_online'), 'error')
+        return
+    elseif source == targetId then
+        TriggerClientEvent('QBCore:Notify', source, 'You cannot teleport to yourself.', 'error')
+        return
     end
 
-    if target ~= 0 then
-        local playerPed = GetPlayerPed(source)
-        local coords = GetEntityCoords(playerPed)
-        TriggerClientEvent('QBCore:Command:TeleportToPlayer', targetId, coords)
-    else
-        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.not_online'), 'error')
-    end
+    local playerPed = GetPlayerPed(source)
+    local coords = GetEntityCoords(playerPed)
+    TriggerClientEvent('QBCore:Command:TeleportToPlayer', targetId, coords)
 end)
+
 
 
 lib.addCommand('tpm', {


### PR DESCRIPTION
added a `/bring [id]` command to be utilized by admins.

ensures the following cases are handled.
1. id is non-numeric. in this case will give a notification asking for valid input.
2. target is not online. in this case will notify player the target is not online.
3. player tries to /bring themselves. in this case it tells player cannot teleport to themselves.

I can work on implementing localization if this is a pr that you guys would like to be added to the project. I am not sure if this functionality is already handled in separate command.