### PR TITLE
refactor: server HasItem and deprecation

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -13,7 +13,7 @@ end
 ---@deprecated use GetCoordsFromEntity from imports/utils.lua
 QBCore.Functions.GetCoords = GetCoordsFromEntity
 
----@deprecated use HasItem from imports/utils.lua
+---@deprecated use https://overextended.dev/ox_inventory/Functions/Client#search
 QBCore.Functions.HasItem = HasItem
 
 -- Utility

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -281,10 +281,7 @@ if isServer then
         return false
     end
 
-    ---QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
-    ---with the specified `amount`. Returns true if the player has at least the amount specified
-    ---and not that the player has the exact amount. If the user passes nil for `amount` then we
-    ---default to 1 - as it's self explainatory within the functions name.
+    ---@deprecated use https://overextended.dev/ox_inventory/Functions/Server#search
     ---@param source Source
     ---@param items string | string[] The item(s) to check for. Can be a string or a table and is mandatory.
     ---@param amount? integer The desired quantity of each item. Acceptable to pass nil, will default to 1.
@@ -426,10 +423,7 @@ else
         end)
     end
 
-    ---QBCore.Functions.HasItem checks if a player has the specified `items` in their inventory
-    ---with the specified `amount`. Returns true if the player has at least the amount specified
-    ---and not that the player has the exact amount. If the user passes nil for `amount` then we
-    ---default to 1 - as it's self explainatory within the functions name.
+    ---@deprecated use https://overextended.dev/ox_inventory/Functions/Client#search
     ---@param items string | string[] The item(s) to check for. Can be a string or a table and is mandatory.
     ---@param amount? integer The desired quantity of each item. Acceptable to pass nil, will default to 1.
     ---@return boolean Returns true if the player has the specified items in the desired quantity, false otherwise

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -357,15 +357,8 @@ QBCore.Functions.IsLicenseInUse = IsLicenseInUse
 
 -- Utility functions
 
----@deprecated use HasItem from imports/utils.lua
----@param source Source
----@param items unknown[]
----@param amount number
----@return boolean
-function QBCore.Functions.HasItem(source, items, amount)
-    if GetResourceState('qb-inventory') == 'missing' then return false end
-    return exports['qb-inventory']:HasItem(source, items, amount)
-end
+---@deprecated use https://overextended.dev/ox_inventory/Functions/Server#search
+QBCore.Functions.HasItem = HasItem
 
 ---@see client/functions.lua:QBCore.Functions.Notify
 function QBCore.Functions.Notify(source, text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon, notifyIconColor)


### PR DESCRIPTION
## Description

- Make server side QBCore.Functions.HasItem call the HasItem function from utility module
- Deprecate all HasItem functions in core in favor of direct ox_inventory calls. We shouldn't provide a wrapper for inventory calls unless we plan to support other inventory resources.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
