### PR TITLE
feat: prevent clients from creating networked entities

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,7 @@
+---@type 'strict'|'relaxed'|'inactive'
+local bucketLockDownMode = GetConvar('qbx:bucketlockdownmode', 'relaxed')
+SetRoutingBucketEntityLockdownMode(0, bucketLockDownMode)
+
 QBCore = {}
 QBCore.Config = QBConfig
 QBCore.Shared = QBShared


### PR DESCRIPTION
## Description

- Can be overridden via convar. Didn't add to QBConfig as we should move towards Convars for cross script configuration
- This could and most likely will cause insecure resources to break

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
