### PR TITLE
feat: add um-idcard

### DIFF
--- a/server/character.lua
+++ b/server/character.lua
@@ -8,26 +8,9 @@ end
 
 ---@param source Source
 local function giveStarterItems(source)
-    local Player = QBCore.Functions.GetPlayer(source)
-
+    exports['um-idcard']:CreateMetaLicense(source, {'id_card', 'driver_license'})
     for _, v in pairs(QBCore.Shared.StarterItems) do
-        if v.item == 'id_card' then
-            local metadata = {
-                type = string.format('%s %s', Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname),
-                description = string.format('CID: %s  \nBirth date: %s  \nSex: %s  \nNationality: %s',
-                Player.PlayerData.citizenid, Player.PlayerData.charinfo.birthdate, Player.PlayerData.charinfo.gender == 0 and Lang:t('info.char_male') or Lang:t('char_female'), Player.PlayerData.charinfo.nationality)
-            }
-            exports.ox_inventory:AddItem(source, v.item, v.amount, metadata)
-        elseif v.item == 'driver_license' then
-            local metadata = {
-                type = 'Class C Driver License',
-                description = string.format('First name: %s  \nLast name: %s  \nBirth date: %s',
-                Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname, Player.PlayerData.charinfo.birthdate)
-            }
-            exports.ox_inventory:AddItem(source, v.item, v.amount, metadata)
-        else
-            exports.ox_inventory:AddItem(source, v.item, v.amount)
-        end
+        exports.ox_inventory:AddItem(source, v.item, v.amount)
     end
 end
 


### PR DESCRIPTION
## Description

- Add um-idcard to multichar givestarteritems, leaving the function in case user wants to add more starter items

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
