### PR TITLE
chore(modules/utils): Remove WaitFor in favor of ox_lib

### DIFF
--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -368,21 +368,7 @@ else
     ---@param timeout integer
     ---@return any
     function WaitFor(cb, timeout)
-        local hasValue = cb()
-        local i = 0
-
-        while not hasValue do
-            if timeout then
-                i += 1
-
-                if i > timeout then return end
-            end
-
-            Wait(0)
-            hasValue = cb()
-        end
-
-        return hasValue
+        return lib.waitFor(cb, nil, timeout)
     end
 
     ---Wrapper for getting an entity handle and network id from a state bag name, [source](https://github.com/overextended/ox_core/blob/main/client/utils.lua)
@@ -392,12 +378,9 @@ else
     function GetEntityAndNetIdFromBagName(bagName)
         local netId = tonumber(bagName:gsub('entity:', ''), 10)
 
-        if not WaitFor(function()
+        lib.waitFor(function()
             return NetworkDoesEntityExistWithNetworkId(netId)
-        end, 10000) then
-            print(('statebag timed out while awaiting entity creation! (%s)'):format(bagName))
-            return 0, 0
-        end
+        end, ('statebag timed out while awaiting entity creation! (%s)'):format(bagName), 10000)
 
         local entity = NetworkDoesEntityExistWithNetworkId(netId) and NetworkGetEntityFromNetworkId(netId) or 0
 

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -362,7 +362,7 @@ else
         ClearDrawOrigin()
     end
 
-    ---Waits for the callback to return a value, [source](https://github.com/overextended/ox_core/blob/main/client/utils.lua)
+    ---@deprecated use https://overextended.dev/ox_lib/Modules/WaitFor/Shared instead
     ---@async
     ---@param cb fun(): any
     ---@param timeout integer

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -362,15 +362,6 @@ else
         ClearDrawOrigin()
     end
 
-    ---@deprecated use https://overextended.dev/ox_lib/Modules/WaitFor/Shared instead
-    ---@async
-    ---@param cb fun(): any
-    ---@param timeout integer
-    ---@return any
-    function WaitFor(cb, timeout)
-        return lib.waitFor(cb, nil, timeout)
-    end
-
     ---Wrapper for getting an entity handle and network id from a state bag name, [source](https://github.com/overextended/ox_core/blob/main/client/utils.lua)
     ---@async
     ---@param bagName string


### PR DESCRIPTION
As this was introduced 3 months ago, I don't suspect it has any users and therefore should be likely safe to remove in favor of the new ox_lib waitFor function