### PR TITLE
REPRO NEEDED: Random death upon login?

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -212,6 +212,7 @@ local function createCharacter(cid)
         cid = cid
     })
     destroyPreviewCam()
+    TriggerServerEvent('qb-cityhall:server:getIDs')
     return true
 end
 

--- a/client/character.lua
+++ b/client/character.lua
@@ -212,7 +212,6 @@ local function createCharacter(cid)
         cid = cid
     })
     destroyPreviewCam()
-    TriggerServerEvent('qb-cityhall:server:getIDs')
     return true
 end
 

--- a/server/events.lua
+++ b/server/events.lua
@@ -31,7 +31,19 @@ AddEventHandler('playerDropped', function(reason)
     if not QBCore.Players[src] then return end
     GlobalState.PlayerCount -= 1
     local Player = QBCore.Players[src]
+    if not Player then return end
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason)
+    local newHunger = Player.PlayerData.metadata.hunger - QBCore.Config.Player.HungerRate
+    local newThirst = Player.PlayerData.metadata.thirst - QBCore.Config.Player.ThirstRate
+    if newHunger <= 0 then
+        newHunger = 0
+    end
+    if newThirst <= 0 then
+        newThirst = 0
+    end
+    Player.Functions.SetMetaData('thirst', newThirst)
+    Player.Functions.SetMetaData('hunger', newHunger)
+    TriggerClientEvent('hud:client:UpdateNeeds', src, newHunger, newThirst)
     Player.Functions.Save()
     QBCore.Player_Buckets[Player.PlayerData.license] = nil
     QBCore.Players[src] = nil

--- a/server/events.lua
+++ b/server/events.lua
@@ -31,20 +31,9 @@ AddEventHandler('playerDropped', function(reason)
     if not QBCore.Players[src] then return end
     GlobalState.PlayerCount -= 1
     local Player = QBCore.Players[src]
-    if not Player then return end
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..' ..'\n **Reason:** ' .. reason)
-    local newHunger = Player.PlayerData.metadata.hunger - QBCore.Config.Player.HungerRate
-    local newThirst = Player.PlayerData.metadata.thirst - QBCore.Config.Player.ThirstRate
-    if newHunger <= 0 then
-        newHunger = 0
-    end
-    if newThirst <= 0 then
-        newThirst = 0
-    end
-    Player.Functions.SetMetaData('thirst', newThirst)
-    Player.Functions.SetMetaData('hunger', newHunger)
-    TriggerClientEvent('hud:client:UpdateNeeds', src, newHunger, newThirst)
     Player.Functions.Save()
+    Wait(200)
     QBCore.Player_Buckets[Player.PlayerData.license] = nil
     QBCore.Players[src] = nil
 end)


### PR DESCRIPTION
## Description

This is an attempt to fix the random scenario where you login and your character is dead. I have not been able to properly pin-point where it is being caused, after looking at some code and I guess plain guessing, I believe it might be related to the way that hunger and thirst are working. Is it possible that when playerDropped is executed we are not saving it properly and even if player is logged out it continues to go down on the server? If we look at logout, we are using it: https://github.com/Qbox-project/qbx-core/blob/8b159d595d275aa38e39efe6cd20fe8cf3f6d19c/server/player.lua#L163

Would love to see if more people can test and reproduce.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
