### PR TITLE
chore(client/functions): deprecate GetPlayerData by function

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -2,7 +2,7 @@ QBCore.Functions = {}
 
 -- Player
 
----get playerData via callback or return
+---@deprecated import playerdata module instead
 ---@param cb? fun(playerData: PlayerData)
 ---@return PlayerData? playerData
 function QBCore.Functions.GetPlayerData(cb)


### PR DESCRIPTION
- importing a module is the preferred method of getting player data