### PR TITLE
refactor(server/functions): using ox_lib acl

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "Lua.runtime.nonstandardSymbol": ["/**/", "`", "+=", "-=", "*=", "/="],
-    "Lua.runtime.version": "Lua 5.4"
+    "Lua.runtime.version": "Lua 5.4",
+    "Lua.diagnostics.globals": [
+        "lib"
+    ]
 }

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -223,6 +223,7 @@ function QBCore.Functions.CanUseItem(item)
     return QBCore.UsableItems[item]
 end
 
+---@deprecated No replacement. See https://overextended.dev/ox_inventory/Functions/Client#useitem
 ---@param source Source
 ---@param item string name
 function QBCore.Functions.UseItem(source, item)
@@ -243,13 +244,14 @@ function QBCore.Functions.IsWhitelisted(source)
 end
 
 -- Setting & Removing Permissions
+-- TODO: Should these be moved to the utility module?
 
 ---@param source Source
 ---@param permission string
 function QBCore.Functions.AddPermission(source, permission)
     if not IsPlayerAceAllowed(source --[[@as string]], permission) then
-        ExecuteCommand(('add_principal player.%s group.%s'):format(source, permission))
-        ExecuteCommand(('add_ace player.%s group.%s allow'):format(source, permission))
+        lib.addPrincipal('player.' .. source, 'group.' .. permission)
+        lib.addAce('player.' .. source, 'group.' .. permission)
         TriggerClientEvent('QBCore:Client:OnPermissionUpdate', source)
         TriggerEvent('QBCore:Server:OnPermissionUpdate', source)
     end
@@ -260,8 +262,8 @@ end
 function QBCore.Functions.RemovePermission(source, permission)
     if permission then
         if IsPlayerAceAllowed(source --[[@as string]], permission) then
-            ExecuteCommand(('remove_principal player.%s group.%s'):format(source, permission))
-            ExecuteCommand(('remove_ace player.%s group.%s allow'):format(source, permission))
+            lib.removePrincipal('player.' .. source, 'group.' .. permission)
+            lib.removeAce('player.' .. source, 'group.' .. permission)
             TriggerClientEvent('QBCore:Client:OnPermissionUpdate', source)
             TriggerEvent('QBCore:Server:OnPermissionUpdate', source)
         end
@@ -269,8 +271,8 @@ function QBCore.Functions.RemovePermission(source, permission)
         local hasUpdated = false
         for _, v in pairs(QBCore.Config.Server.Permissions) do
             if IsPlayerAceAllowed(source --[[@as string]], v) then
-                ExecuteCommand(('remove_principal player.%s group.%s'):format(source, v))
-                ExecuteCommand(('remove_ace player.%s group.%s allow'):format(source, v))
+                lib.removePrincipal('player.' .. source, 'group.' .. v)
+                lib.removeAce('player.' .. source, 'group.' .. v)
                 hasUpdated = true
             end
         end
@@ -283,7 +285,7 @@ end
 
 -- Checking for Permission Level
 ---@param source Source
----@param permission string
+---@param permission string|string[]
 ---@return boolean
 function QBCore.Functions.HasPermission(source, permission)
     if type(permission) == "string" then


### PR DESCRIPTION
- instead of ExecuteCommand directly to make the code a bit cleaner
- also snuck in deprecation of qb-inventory function UseItem