### PR TITLE
fix(functions): use text as description when no subTitle specified

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -50,11 +50,11 @@ function QBCore.Functions.Notify(text, notifyType, duration, subTitle, notifyPos
     if type(text) == "table" then
         title = text.text or 'Placeholder'
         description = text.caption or nil
-    elseif not subTitle then
-        description = text
-    else
+    elseif subTitle then
         title = text
         description = subTitle
+    else
+        description = text
     end
     local position = notifyPosition or QBConfig.NotifyPosition
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -50,6 +50,8 @@ function QBCore.Functions.Notify(text, notifyType, duration, subTitle, notifyPos
     if type(text) == "table" then
         title = text.text or 'Placeholder'
         description = text.caption or nil
+    elseif not subTitle then
+        description = text
     else
         title = text
         description = subTitle

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -368,11 +368,11 @@ function QBCore.Functions.Notify(source, text, notifyType, duration, subTitle, n
     if type(text) == "table" then
         title = text.text or 'Placeholder'
         description = text.caption or nil
-    elseif not subTitle then
-        description = text
-    else
+    elseif subTitle then
         title = text
         description = subTitle
+    else
+        description = text
     end
     local position = notifyPosition or QBConfig.NotifyPosition
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -368,6 +368,8 @@ function QBCore.Functions.Notify(source, text, notifyType, duration, subTitle, n
     if type(text) == "table" then
         title = text.text or 'Placeholder'
         description = text.caption or nil
+    elseif not subTitle then
+        description = text
     else
         title = text
         description = subTitle


### PR DESCRIPTION
## Description

This keeps UI consistency between ox_inventory and previous notifications, since this text is/was not bold respectively.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
