### PR TITLE
Update resource argument and enable print bool

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -1,4 +1,4 @@
-if QBCore.Config.Characters.UseExternalCharacters or not lib.checkDependency('overextended/ox_lib', '3.10.0') then return end
+if QBCore.Config.Characters.UseExternalCharacters or not lib.checkDependency('ox_lib', '3.10.0', true) then return end
 
 local previewCam = nil
 local randomLocation = QBCore.Config.Characters.Locations[math.random(1, #QBCore.Config.Characters.Locations)]


### PR DESCRIPTION
## Description

Currently you will skip the character selection process because lib.checkDependency() doesn't find ox_lib as 'overextended/ox_lib' - the version returned is 'unknown'. This was hard to track down because the print was disabled.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
