### PR TITLE
refactor: creating QBCore.Shared table in a module

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,7 +1,7 @@
 QBCore = {}
 QBCore.PlayerData = {}
 QBCore.Config = QBConfig
-QBCore.Shared = QBShared
+QBCore.Shared = require 'shared.main'
 
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Client/ instead
 QBCore.ClientCallbacks = {}

--- a/server/loops.lua
+++ b/server/loops.lua
@@ -20,9 +20,9 @@ end)
 lib.cron.new(('*/%s * * * *'):format(QBCore.Config.Money.PaycheckTimeout), function()
     for _, Player in pairs(QBCore.Players) do
         if Player then
-            local payment = QBShared.Jobs[Player.PlayerData.job.name].grades[Player.PlayerData.job.grade.level].payment
+            local payment = QBCore.Shared.Jobs[Player.PlayerData.job.name].grades[Player.PlayerData.job.grade.level].payment
             if not payment then payment = Player.PlayerData.job.payment end
-            if Player.PlayerData.job and payment > 0 and (QBShared.Jobs[Player.PlayerData.job.name].offDutyPay or Player.PlayerData.job.onduty) then
+            if Player.PlayerData.job and payment > 0 and (QBCore.Shared.Jobs[Player.PlayerData.job.name].offDutyPay or Player.PlayerData.job.onduty) then
                 if QBCore.Config.Money.PaycheckSociety then
                     local account = exports['qbx-management']:GetAccount(Player.PlayerData.job.name)
                     if account ~= 0 then -- Checks if player is employed by a society

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,7 +6,7 @@ if not lib.checkDependency('ox_lib', '3.10.0', true) then error() return end
 
 QBCore = {}
 QBCore.Config = QBConfig
-QBCore.Shared = QBShared
+QBCore.Shared = require 'shared.main'
 
 ---@deprecated use https://overextended.github.io/docs/ox_lib/Callback/Lua/Server instead
 QBCore.ClientCallbacks = {}

--- a/shared/gangs.lua
+++ b/shared/gangs.lua
@@ -1,11 +1,9 @@
-QBShared = QBShared or {}
-
 ---@class Gang
 ---@field label string
 ---@field grades table<integer, {name: string, isboss: boolean}>
 
 ---@type table<string, Gang>
-QBShared.Gangs = {
+return {
 	['none'] = {
 		label = 'No Gang',
 		grades = {

--- a/shared/items.lua
+++ b/shared/items.lua
@@ -1,5 +1,4 @@
-QBShared = QBShared or {}
-QBShared.Items = {
+return {
 	-- WEAPONS
 	-- Melee
 	['weapon_unarmed'] 				 = {['name'] = 'weapon_unarmed', 		 	  	['label'] = 'Fists', 					['weight'] = 1000, 		['type'] = 'weapon',	['ammotype'] = nil, 					['image'] = 'placeholder.png', 			['unique'] = true, 		['useable'] = false, 	['description'] = 'Fisticuffs'},

--- a/shared/jobs.lua
+++ b/shared/jobs.lua
@@ -1,6 +1,3 @@
-QBShared = QBShared or {}
-QBShared.ForceJobDefaultDutyAtLogin = true -- true: Force duty state to jobdefaultDuty | false: set duty state from database last saved
-
 ---@class Job
 ---@field label string
 ---@field type? string
@@ -9,7 +6,7 @@ QBShared.ForceJobDefaultDutyAtLogin = true -- true: Force duty state to jobdefau
 ---@field grades table<integer, {name: string, payment: number, isboss: boolean}>
 
 ---@type table<string, Job>
-QBShared.Jobs = {
+return {
 	['unemployed'] = {
 		label = 'Civilian',
 		defaultDuty = true,

--- a/shared/locations.lua
+++ b/shared/locations.lua
@@ -1,6 +1,4 @@
-QBShared = QBShared or {}
-
-QBShared.Locations = {
+return {
     -- Unknown/Random/Vanilla
     ['burgershot'] = vector4(-1199.0568, -882.4495, 13.3500, 209.1105),
     ['casino'] = vector4(923.2289, 47.3113, 81.1063, 237.6052),

--- a/shared/main.lua
+++ b/shared/main.lua
@@ -1,34 +1,50 @@
-QBShared = QBShared or {}
+local qbShared = {}
+qbShared.Gangs = require 'gangs'
+qbShared.Items = require 'items'
+qbShared.ForceJobDefaultDutyAtLogin = true -- true: Force duty state to jobdefaultDuty | false: set duty state from database last saved
+qbShared.Jobs = require 'jobs'
+qbShared.Locations = require 'locations'
+qbShared.Vehicles = require 'vehicles'
+qbShared.Weapons = require 'weapons'
+
+---@type table<number, Vehicle>
+qbShared.VehicleHashes = {}
+
+for _, v in pairs(qbShared.Vehicles) do
+	qbShared.VehicleHashes[v.hash] = v
+end
 
 ---@deprecated use CommaValue from imports/utils.lua
-QBShared.CommaValue = CommaValue
+qbShared.CommaValue = CommaValue
 
 ---@deprecated use RandomLetter from imports/utils.lua
-QBShared.RandomStr = RandomLetter
+qbShared.RandomStr = RandomLetter
 
 ---@deprecated use RandomNumber from imports/utils.lua
-QBShared.RandomInt = RandomNumber
+qbShared.RandomInt = RandomNumber
 
 ---@deprecated use string.split from imports/utils.lua
-QBShared.SplitStr = string.split
+qbShared.SplitStr = string.split
 
 ---@deprecated use string.trim from imports/utils.lua
-QBShared.Trim = string.trim
+qbShared.Trim = string.trim
 
 ---@deprecated use string.firstToUpper from imports/utils.lua
-QBShared.FirstToUpper = string.firstToUpper
+qbShared.FirstToUpper = string.firstToUpper
 
 ---@deprecated use math.round from imports/utils.lua
-QBShared.Round = math.round
+qbShared.Round = math.round
 
 ---@deprecated use ChangeVehicleExtra from imports/utils.lua
-QBShared.ChangeVehicleExtra = ChangeVehicleExtra
+qbShared.ChangeVehicleExtra = ChangeVehicleExtra
 
 ---@deprecated use SetVehicleExtras from imports/utils.lua
-QBShared.SetDefaultVehicleExtras = SetVehicleExtras
+qbShared.SetDefaultVehicleExtras = SetVehicleExtras
 
 ---@deprecated use MaleNoGloves from imports/utils.lua
-QBShared.MaleNoGloves = MaleNoGloves
+qbShared.MaleNoGloves = MaleNoGloves
 
 ---@deprecated use FemaleNoGloves from imports/utils.lua
-QBShared.FemaleNoGloves = FemaleNoGloves
+qbShared.FemaleNoGloves = FemaleNoGloves
+
+return qbShared

--- a/shared/vehicles.lua
+++ b/shared/vehicles.lua
@@ -1,8 +1,3 @@
-QBShared = QBShared or {}
-
----@type table<number, Vehicle>
-QBShared.VehicleHashes = {}
-
 ---@class Vehicle
 ---@field name string
 ---@field brand string
@@ -12,7 +7,7 @@ QBShared.VehicleHashes = {}
 ---@field hash string | integer actually just an integer but string is required for types to align when using `asbo` for example
 
 ---@type table<string, Vehicle>
-QBShared.Vehicles = {
+return {
 	--- Compacts
 	asbo = {
 		name = 'Asbo',
@@ -4086,7 +4081,3 @@ QBShared.Vehicles = {
         hash = `weevil2`,
     },
 }
-
-for _, v in pairs(QBShared.Vehicles) do
-	QBShared.VehicleHashes[v.hash] = v
-end

--- a/shared/weapons.lua
+++ b/shared/weapons.lua
@@ -1,5 +1,3 @@
-QBShared = QBShared or {}
-
 ---@class Weapon
 ---@field name string
 ---@field label string
@@ -8,7 +6,7 @@ QBShared = QBShared or {}
 ---@field damagereason string
 
 ---@type table<number, Weapon>
-QBShared.Weapons = {
+return {
 	-- // WEAPONS
 	-- Melee
 	[`weapon_unarmed`] 				 = {name = 'weapon_unarmed', 		label = 'Fists', 				weapontype = 'Melee',	ammotype = nil, damagereason = 'Melee killed / Whacked / Executed / Beat down / Murdered / Battered'},


### PR DESCRIPTION
## Description
It strikes me a bit strange that we have a QBShared global that is mutated across several different files. This PR uses ox_lib require to build up the QBShared table and therefore create some Immutability for it. This also gives up deterministic file execution order, as well as reducing code scope.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
