### PR TITLE
fix(utils): remove give keys on server side vehicle creation

### DIFF
--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -224,7 +224,6 @@ if isServer then
         end
 
         if warp then SetPedIntoVehicle(ped, veh, -1) end
-        TriggerClientEvent('vehiclekeys:client:SetOwner', source, GetPlate(veh))
         Entity(veh).state:set('initVehicle', true, true)
         return NetworkGetNetworkIdFromEntity(veh)
     end


### PR DESCRIPTION
## Description

I believe this does not work from the modules, I can't say the reason exactly, I see that modules are loaded as files. But it appears that on the modules, the spawnvehicle function, will not provide the keys. I was able to get the duplicate message from this function that keys were given plus the code on the client side. If I NetToVeh the NetId of this vehicle and then on the client side apply the keys, it will work correctly.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
