### PR TITLE
refactor: character creation flow to set PlayerData

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -1,12 +1,3 @@
--- Player load and unload handling
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    ShutdownLoadingScreenNui()
-    IsLoggedIn = true
-    if not QBConfig.Server.PVP then return end
-    SetCanAttackFriendly(cache.ped, true, false)
-    NetworkSetFriendlyFireOption(true)
-end)
-
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     IsLoggedIn = false
 end)
@@ -154,13 +145,6 @@ RegisterNetEvent('QBCore:Command:DeleteVehicle', function()
 end)
 
 -- Other stuff
-
----@param val PlayerData
-RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
-    local invokingResource = GetInvokingResource()
-    if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
-    QBCore.PlayerData = val
-end)
 
 ---@see client/functions.lua:QBCore.Functions.Notify
 RegisterNetEvent('QBCore:Notify', function(text, notifyType, duration, subTitle, notifyPosition, notifyStyle, notifyIcon, notifyIconColor)

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -1,5 +1,5 @@
 QBCore = QBCore or exports['qbx-core']:GetCoreObject()
-PlayerData = QBCore.PlayerData
+PlayerData = QBCore.PlayerData -- luacheck: ignore
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     PlayerData = {}

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -1,15 +1,11 @@
 QBCore = QBCore or exports['qbx-core']:GetCoreObject()
 PlayerData = QBCore.PlayerData
 
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    PlayerData = QBCore.PlayerData
-end)
-
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     PlayerData = {}
 end)
 
-function SetPlayerData(value)
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(value)
     PlayerData = value
     QBCore.PlayerData = value
-end
+end)

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -3,21 +3,13 @@ PlayerData = QBCore.PlayerData
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     PlayerData = QBCore.PlayerData
-    if OnPlayerData then
-        OnPlayerData(PlayerData)
-    end
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     PlayerData = {}
-    if OnPlayerData then
-        OnPlayerData(PlayerData)
-    end
 end)
 
-RegisterNetEvent('QBCore:Player:SetPlayerData', function(value)
+function SetPlayerData(value)
     PlayerData = value
-    if OnPlayerData then
-        OnPlayerData(PlayerData)
-    end
-end)
+    QBCore.PlayerData = value
+end

--- a/server/player.lua
+++ b/server/player.lua
@@ -216,7 +216,6 @@ function playerObj.CreatePlayer(playerData, Offline)
 
     function self.Functions.UpdatePlayerData()
         if self.Offline then return end -- Unsupported for Offline Players
-        SetPlayerData(self.PlayerData)
         TriggerEvent('QBCore:Player:SetPlayerData', self.PlayerData)
         TriggerClientEvent('QBCore:Player:SetPlayerData', self.PlayerData.source, self.PlayerData)
     end

--- a/server/player.lua
+++ b/server/player.lua
@@ -10,25 +10,24 @@ local playerObj = {}
 ---@param source Source
 ---@param citizenid? string
 ---@param newData? PlayerEntity
----@return boolean sourceExists true if source exists
+---@return Player? player if logged in successfully
 function playerObj.Login(source, citizenid, newData)
     if not source or source == '' then
         lib.print.error('QBCORE.PLAYER.LOGIN - NO SOURCE GIVEN!')
-        return false
+        return
     end
     if citizenid then
         local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
         local playerData = FetchPlayerEntity(citizenid)
         if playerData and (license2 == playerData.license or license == playerData.license) then
-            QBCore.Player.CheckPlayerData(source, playerData)
+            return QBCore.Player.CheckPlayerData(source, playerData)
         else
             DropPlayer(tostring(source), Lang:t("info.exploit_dropped"))
             TriggerEvent('qb-log:server:CreateLog', 'anticheat', 'Anti-Cheat', 'white', ('%s Has Been Dropped For Character Joining Exploit'):format(GetPlayerName(source)), false)
         end
     else
-        QBCore.Player.CheckPlayerData(source, newData)
+        return QBCore.Player.CheckPlayerData(source, newData)
     end
-    return true
 end
 
 ---@param citizenid string
@@ -42,7 +41,7 @@ end
 
 ---@param source? integer if player is online
 ---@param playerData? PlayerEntity|PlayerData
----@return Player? player if offline
+---@return Player player
 function playerObj.CheckPlayerData(source, playerData)
     playerData = playerData or {}
     local Offline = true
@@ -208,7 +207,7 @@ end
 ---Will cause major issues!
 ---@param playerData PlayerData
 ---@param Offline boolean
----@return Player? player if player is offline
+---@return Player player
 function playerObj.CreatePlayer(playerData, Offline)
     local self = {}
     self.Functions = {}
@@ -217,6 +216,7 @@ function playerObj.CreatePlayer(playerData, Offline)
 
     function self.Functions.UpdatePlayerData()
         if self.Offline then return end -- Unsupported for Offline Players
+        SetPlayerData(self.PlayerData)
         TriggerEvent('QBCore:Player:SetPlayerData', self.PlayerData)
         TriggerClientEvent('QBCore:Player:SetPlayerData', self.PlayerData.source, self.PlayerData)
     end
@@ -474,17 +474,17 @@ function playerObj.CreatePlayer(playerData, Offline)
         self[fieldName] = data
     end
 
-    if self.Offline then
-        return self
-    else
+    if not self.Offline then
         QBCore.Players[self.PlayerData.source] = self
         QBCore.Player.Save(self.PlayerData.source)
 
         -- At this point we are safe to emit new instance to third party resource for load handling
         GlobalState.PlayerCount += 1
-        TriggerEvent('QBCore:Server:PlayerLoaded', self)
         self.Functions.UpdatePlayerData()
+        TriggerEvent('QBCore:Server:PlayerLoaded', self)
     end
+
+    return self
 end
 
 ---Save player info to database (make sure citizenid is the primary key in your database)


### PR DESCRIPTION
## Description

- refactoring character creation flow to convert events to functions where possible and limit net events
- setting PlayerData in module to ensure PlayerData is set before the OnPlayerLoaded event is triggered. I moved the events that trigger setting of PlayerData to come before the event for OnPlayerLoaded. In theory I think this still means that OnPlayerLoaded handlers could handle the event before PlayerData has been set, but this should make it less likely. Since this is an improvement, will leave it as is, but having the PlayerData guaranteed before the OnPlayerLoaded event is set would be the best solution.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
