### PR TITLE
chore: remove qbx-core GetCoreObject export in favor of module

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -5,8 +5,3 @@ QBCore.Shared = require 'shared.main'
 QBCore.Functions = require 'client.functions'
 
 IsLoggedIn = false
-
----@deprecated import QBCore using module 'qbx-core:core' https://qbox-docs.vercel.app/resources/core/import
-exports('GetCoreObject', function()
-    return QBCore
-end)

--- a/modules/core.lua
+++ b/modules/core.lua
@@ -1,1 +1,1 @@
-QBCore = exports['qbx-core']:GetCoreObject()
+QbxCore = QBCore

--- a/modules/core.lua
+++ b/modules/core.lua
@@ -1,1 +1,1 @@
-QbxCore = QBCore
+QbxCore = QBCore -- luacheck: ignore

--- a/modules/core.lua
+++ b/modules/core.lua
@@ -1,1 +1,1 @@
-QbxCore = QBCore -- luacheck: ignore
+QBX = QBCore -- luacheck: ignore

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -1,4 +1,4 @@
-QBCore = QBCore or exports['qbx-core']:GetCoreObject()
+QbxCore = QBCore
 PlayerData = QBCore.PlayerData -- luacheck: ignore
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -1,4 +1,4 @@
-QbxCore = QBCore -- luacheck: ignore
+QBX = QBCore -- luacheck: ignore
 PlayerData = QBCore.PlayerData -- luacheck: ignore
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()

--- a/modules/playerdata.lua
+++ b/modules/playerdata.lua
@@ -1,4 +1,4 @@
-QbxCore = QBCore
+QbxCore = QBCore -- luacheck: ignore
 PlayerData = QBCore.PlayerData -- luacheck: ignore
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()


### PR DESCRIPTION
## Description

- Removes exports['qbx-core']:GetCoreObject() as people should just be using the module
- exports['qb-core']:GetCoreObject() will continue to work for those needing backwards compatibility and can be used at the same time as a module to switch a resource over gradually off of the qb core object
- Also renaming the global variable supplied by the module to 'QbxCore' so that resources that currently contain QBCore variables won't have a conflict, and both can be used at the same time. The rename also helps communicate that QbxCore does not contain the same functions that QBCore does.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
