### PR TITLE
fix: broken login compatibility

### DIFF
--- a/client/character.lua
+++ b/client/character.lua
@@ -159,14 +159,6 @@ local function checkStrings(dialog, input)
     return true
 end
 
-local function onPlayerLoaded()
-    ShutdownLoadingScreenNui()
-    IsLoggedIn = true
-    if not QBConfig.Server.PVP then return end
-    SetCanAttackFriendly(cache.ped, true, false)
-    NetworkSetFriendlyFireOption(true)
-end
-
 local function spawnDefault() -- We use a callback to make the server wait on this to be done
     DoScreenFadeOut(500)
 
@@ -179,7 +171,6 @@ local function spawnDefault() -- We use a callback to make the server wait on th
     pcall(function() exports.spawnmanager:spawnPlayer() end)
 
     TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
-    onPlayerLoaded()
     TriggerEvent('QBCore:Client:OnPlayerLoaded')
     TriggerServerEvent('qb-houses:server:SetInsideMeta', 0, false)
     TriggerServerEvent('qb-apartments:server:SetInsideMeta', 0, 0, false)
@@ -347,7 +338,6 @@ RegisterNetEvent('qbx-core:client:spawnNoApartments', function() -- This event i
     Wait(500)
     DoScreenFadeIn(250)
     TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
-    onPlayerLoaded()
     TriggerEvent('QBCore:Client:OnPlayerLoaded')
     TriggerServerEvent('qb-houses:server:SetInsideMeta', 0, false)
     TriggerServerEvent('qb-apartments:server:SetInsideMeta', 0, 0, false)

--- a/client/events.lua
+++ b/client/events.lua
@@ -1,3 +1,12 @@
+-- Player load and unload handling
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+    ShutdownLoadingScreenNui()
+    IsLoggedIn = true
+    if not QBConfig.Server.PVP then return end
+    SetCanAttackFriendly(cache.ped, true, false)
+    NetworkSetFriendlyFireOption(true)
+end)
+
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     IsLoggedIn = false
 end)

--- a/client/events.lua
+++ b/client/events.lua
@@ -7,12 +7,12 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     NetworkSetFriendlyFireOption(true)
 end)
 
----@param val PlayerData
-RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
-    local invokingResource = GetInvokingResource()
-    if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
-    QBCore.PlayerData = val
-end)
+-- ---@param val PlayerData
+-- RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
+--     local invokingResource = GetInvokingResource()
+--     if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
+--     QBCore.PlayerData = val
+-- end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     IsLoggedIn = false

--- a/client/events.lua
+++ b/client/events.lua
@@ -7,12 +7,12 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     NetworkSetFriendlyFireOption(true)
 end)
 
--- ---@param val PlayerData
--- RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
---     local invokingResource = GetInvokingResource()
---     if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
---     QBCore.PlayerData = val
--- end)
+---@param val PlayerData
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
+    local invokingResource = GetInvokingResource()
+    if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
+    QBCore.PlayerData = val
+end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     IsLoggedIn = false

--- a/client/events.lua
+++ b/client/events.lua
@@ -7,6 +7,13 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     NetworkSetFriendlyFireOption(true)
 end)
 
+---@param val PlayerData
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
+    local invokingResource = GetInvokingResource()
+    if invokingResource and invokingResource ~= GetCurrentResourceName() then return end
+    QBCore.PlayerData = val
+end)
+
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     IsLoggedIn = false
 end)

--- a/server/character.lua
+++ b/server/character.lua
@@ -54,7 +54,7 @@ end)
 
 lib.callback.register('qbx-core:server:loadCharacter', function(citizenId)
     local src = source
-    local player = QBCore.Player.Login(src, citizenId)
+    local player = QBCore.Player.LoginV2(src, citizenId)
     if not player then return end
 
     SetPlayerRoutingBucket(src, 0)
@@ -69,7 +69,7 @@ lib.callback.register('qbx-core:server:createCharacter', function(data)
     local newData = {}
     newData.charinfo = data
 
-    local player = QBCore.Player.Login(src, nil, newData)
+    local player = QBCore.Player.LoginV2(src, nil, newData)
     if not player then return end
 
     giveStarterItems(src)

--- a/server/player.lua
+++ b/server/player.lua
@@ -4,18 +4,25 @@ local playerObj = {}
 ---@field source? Source present if player is online
 ---@field optin? boolean present if player is online
 
+---@deprecated call LoginV2
+---@param source Source
+---@param citizenid? string
+---@param newData? PlayerEntity
+---@return boolean success
+function playerObj.Login(source, citizenid, newData)
+    if not source or source == '' then
+        lib.print.error('QBCORE.PLAYER.LOGIN - NO SOURCE GIVEN!')
+        return false
+    end
+    return playerObj.LoginV2(source, citizenid, newData) and true or false
+end
+
 ---On player login get their data or set defaults
----Don't touch any of this unless you know what you are doing
----Will cause major issues!
 ---@param source Source
 ---@param citizenid? string
 ---@param newData? PlayerEntity
 ---@return Player? player if logged in successfully
-function playerObj.Login(source, citizenid, newData)
-    if not source or source == '' then
-        lib.print.error('QBCORE.PLAYER.LOGIN - NO SOURCE GIVEN!')
-        return
-    end
+function playerObj.LoginV2(source, citizenid, newData)
     if citizenid then
         local license, license2 = GetPlayerIdentifierByType(source --[[@as string]], 'license'), GetPlayerIdentifierByType(source --[[@as string]], 'license2')
         local playerData = FetchPlayerEntity(citizenid)


### PR DESCRIPTION
- Partial rollback of #166 
- Handling player loaded tasks via event again for those that disable core multi char
- setting core player data via event again for those that don't load the PlayerData module
- introducing playerObj.LoginV2 to return the player obj while reverting Login to be a boolean return for compatibility